### PR TITLE
Update to v0.20.6

### DIFF
--- a/me.dumke.Reinschrift.yml
+++ b/me.dumke.Reinschrift.yml
@@ -34,7 +34,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/danst0/ReinschriftTodo.git
-        tag: v0.20.5
+        tag: v0.20.6
       - generated-sources.json
       - type: shell
         commands:


### PR DESCRIPTION
Updates Reinschrift to version 0.20.6

Changes: https://github.com/danst0/ReinschriftTodo/releases/tag/v0.20.6