### PR TITLE
Update to v0.22.8

### DIFF
--- a/me.dumke.Reinschrift.yml
+++ b/me.dumke.Reinschrift.yml
@@ -34,7 +34,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/danst0/ReinschriftTodo.git
-        tag: v0.22.1
+        tag: v0.22.3
       - generated-sources.json
       - type: shell
         commands:

--- a/me.dumke.Reinschrift.yml
+++ b/me.dumke.Reinschrift.yml
@@ -34,7 +34,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/danst0/ReinschriftTodo.git
-        tag: v0.22.3
+        tag: v0.22.8
       - generated-sources.json
       - type: shell
         commands:


### PR DESCRIPTION
Updates Reinschrift to version 0.22.8

Changes: https://github.com/danst0/ReinschriftTodo/releases/tag/v0.22.8

Since v0.22.1 (currently pending publish):
- New tasks added in the My Day view are planned for today automatically
- Fix: postpone no longer drops the rec: recurrence token (web)
- Translation completions (es/fr/ja/sv), repository cleanup, CI pipeline
- Web app: all mypy findings fixed